### PR TITLE
Make bluetooth not discoverable via large screen deep link flow

### DIFF
--- a/src/com/android/settings/SettingsActivity.java
+++ b/src/com/android/settings/SettingsActivity.java
@@ -68,6 +68,7 @@ import com.android.settings.homepage.SettingsHomepageActivity;
 import com.android.settings.homepage.SliceDeepLinkHomepageActivity;
 import com.android.settings.homepage.TopLevelSettings;
 import com.android.settings.overlay.FeatureFactory;
+import com.android.settings.password.PasswordUtils;
 import com.android.settings.wfd.WifiDisplaySettings;
 import com.android.settings.widget.SettingsMainSwitchBar;
 import com.android.settingslib.core.instrumentation.Instrumentable;
@@ -149,6 +150,8 @@ public class SettingsActivity extends SettingsBaseActivity
      * Set true when the deep link intent is from a slice
      */
     public static final String EXTRA_IS_FROM_SLICE = "is_from_slice";
+
+    public static final String EXTRA_INITIAL_CALLING_PACKAGE = "initial_calling_package";
 
     /**
      * Personal or Work profile tab of {@link ProfileSelectFragment}
@@ -399,6 +402,8 @@ public class SettingsActivity extends SettingsBaseActivity
     }
 
     private void launchHomepageForTwoPaneDeepLink(Intent intent) {
+        intent.putExtra(EXTRA_INITIAL_CALLING_PACKAGE, PasswordUtils.getCallingAppPackageName(
+                getActivityToken()));
         final Intent trampolineIntent;
         if (intent.getBooleanExtra(EXTRA_IS_FROM_SLICE, false)) {
             // Get menu key for slice deep link case.
@@ -457,6 +462,17 @@ public class SettingsActivity extends SettingsBaseActivity
         }
 
         return true;
+    }
+
+    /** Returns the initial calling package name that launches the activity. */
+    public String getInitialCallingPackage() {
+        String callingPackage = PasswordUtils.getCallingAppPackageName(getActivityToken());
+        if (!TextUtils.equals(callingPackage, getPackageName())) {
+            return callingPackage;
+        }
+
+        String initialCallingPackage = getIntent().getStringExtra(EXTRA_INITIAL_CALLING_PACKAGE);
+        return TextUtils.isEmpty(initialCallingPackage) ? callingPackage : initialCallingPackage;
     }
 
     /** Returns the initial fragment name that the activity will launch. */

--- a/src/com/android/settings/connecteddevice/ConnectedDeviceDashboardFragment.java
+++ b/src/com/android/settings/connecteddevice/ConnectedDeviceDashboardFragment.java
@@ -58,9 +58,9 @@ import android.util.Log;
 import androidx.annotation.VisibleForTesting;
 
 import com.android.settings.R;
+import com.android.settings.SettingsActivity;
 import com.android.settings.core.SettingsUIDeviceConfig;
 import com.android.settings.dashboard.DashboardFragment;
-import com.android.settings.password.PasswordUtils;
 import com.android.settings.search.BaseSearchIndexProvider;
 import com.android.settings.slices.SlicePreferenceController;
 import com.android.settingslib.search.SearchIndexable;
@@ -104,8 +104,8 @@ public class ConnectedDeviceDashboardFragment extends DashboardFragment {
         super.onAttach(context);
         final boolean nearbyEnabled = DeviceConfig.getBoolean(DeviceConfig.NAMESPACE_SETTINGS_UI,
                 SettingsUIDeviceConfig.BT_NEAR_BY_SUGGESTION_ENABLED, true);
-        String callingAppPackageName = PasswordUtils.getCallingAppPackageName(
-                getActivity().getActivityToken());
+        String callingAppPackageName = ((SettingsActivity) getActivity())
+                .getInitialCallingPackage();
         String action = getIntent() != null ? getIntent().getAction() : "";
         if (DEBUG) {
             Log.d(TAG, "onAttach() calling package name is : " + callingAppPackageName


### PR DESCRIPTION
Deep links on large screen devices starts a homepage activity on the left pane, and then starts the target activity on the right pane. This flow overrides the calling package, and the target activity can't know who initially calls it.

Thus, we store the initial calling package in the intent, so the Connected devices page is able to make bluetooth not discoverable when it's called from unintended apps on large screen devices.

Bug: 234440688
Test: robotest, manual
Change-Id: I4ddcd4e083c002ece9d10aabdb4af4a41de55ce7 Merged-In: I4ddcd4e083c002ece9d10aabdb4af4a41de55ce7 (cherry picked from commit 5df14831b8d0bbae062c644cfa987378ea2ca9d4)
Merged-In: I4ddcd4e083c002ece9d10aabdb4af4a41de55ce7
Signed-off-by: bagaskara815 <bagaskara815@gmail.com>